### PR TITLE
Stripe Webhooks controller and background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,78 @@ Simple rails application that receives and processes events from Stripe.
 - **Rails**: 8.x  
 - **Database**:  
   - **Production**: PostgreSQL  
-  - **Development**: SQLite  
+  - **Development**: SQLite
+
+
+  README
+
+Simple rails application that receives and processes events from Stripe.
+
+System Requirements
+
+- Ruby: 3.3.6
+- Rails: 8.x
+- Database:
+  - Production: PostgreSQL
+  - Development: SQLite
+
+Setup Instructions
+
+1️⃣ Install Dependencies
+Run the setup script to install required gems and prepare the database:
+bin/setup
+
+This will:
+- Run bundle install
+- Prepare the database (rails db:prepare)
+- Clear logs and temp files
+
+If you prefer manual setup:
+bundle install
+rails db:prepare
+
+2️⃣ Set Environment Variables
+Create a .env file or export environment variables:
+STRIPE_SECRET_KEY="your_stripe_secret_key"
+STRIPE_WEBHOOK_SECRET="your_webhook_secret"
+
+Ensure you replace "your_stripe_secret_key" and "your_webhook_secret" with your actual credentials.
+
+3️⃣ Start Stripe CLI for Webhook Testing
+Run Stripe CLI to forward webhooks to your local app:
+stripe listen --forward-to localhost:3000/webhooks/stripe
+
+This will return:
+> Ready! You are using Stripe API Version [YYYY-MM-DD]. Your webhook signing secret is whsec_XXXX
+
+Copy "whsec_XXXX" and update your .env file:
+STRIPE_WEBHOOK_SECRET="whsec_XXXX"
+
+4️⃣ Start the Application
+Start Rails server and background job processing:
+web: bundle exec rails server -p $PORT
+worker: bin/jobs
+
+Alternatively, run each process manually:
+rails server
+bin/jobs
+
+5️⃣ Trigger Stripe Events for Testing
+Once your app is running, manually trigger Stripe events:
+
+Test Subscription Creation
+stripe trigger customer.subscription.created
+
+Test Subscription Deletion
+stripe trigger customer.subscription.deleted
+
+This will simulate Stripe sending webhooks and validate that your application correctly processes these events.
+
+
+💡 Notes
+- Webhooks are idempotent, meaning the app will ignore duplicate events.
+- Failed events will retry automatically up to 3 times before being marked as failed.
+
+📖 Additional Resources
+- Stripe Webhook Documentation: https://docs.stripe.com/webhooks
+- Stripe CLI: https://docs.stripe.com/cli

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -1,0 +1,64 @@
+require "stripe"
+
+module Webhooks
+  class StripeController < ActionController::API
+    STRIPE_SIGNATURE_HEADER = "HTTP_STRIPE_SIGNATURE".freeze
+    STRIPE_WEBHOOK_SECRET = "STRIPE_WEBHOOK_SECRET".freeze
+
+    before_action :verify_signature
+
+    def create
+      event = register_event!
+
+      # TODO: Move this job outside of the webhook request to return `head :ok` immediately.
+      # Currently, we enqueue the job directly, but an alternative approach is:
+      # - Use a scheduled job to process events in batches at regular intervals.
+      # - This ensures webhook requests remain as fast as possible without any queuing delays.
+      EventProcessorJob.perform_later(event.external_id) if event
+
+      head :ok
+    end
+
+    private
+
+    def register_event!
+      # In a case that Stripe sends the event mutiple times, we should not create a new event.
+      existing_event = StripeEvent.find_by(external_id: @event["id"])
+      return existing_event if existing_event.present?
+
+      event = StripeEvent.create!(
+        external_id: @event["id"],
+        name: @event["type"],
+        payload: @event.to_h,
+        status: ::Event::PENDING
+      )
+
+      event
+    end
+
+    def verify_signature
+      return render json: { error: "Empty payload" }, status: :bad_request if payload.blank?
+
+      begin
+        @event = Stripe::Webhook.construct_event(payload, signature, secret)
+      rescue JSON::ParserError
+        render json: { error: "Invalid payload" }, status: :bad_request and return
+      rescue Stripe::SignatureVerificationError
+        Rails.logger.error "⚠️  Signature verification failed"
+        render json: { error: "Invalid signature" }, status: :bad_request and return
+      end
+    end
+
+    def payload
+      @payload ||= request.body&.read
+    end
+
+    def signature
+      @signature ||= request.env[STRIPE_SIGNATURE_HEADER]
+    end
+
+    def secret
+      @secret ||= ENV[STRIPE_WEBHOOK_SECRET]
+    end
+  end
+end

--- a/app/jobs/event_processor_job.rb
+++ b/app/jobs/event_processor_job.rb
@@ -1,0 +1,43 @@
+class EventProcessorJob < ApplicationJob
+  queue_as :default
+
+  ALLOWED_EVENTS = %w[
+    checkout.session.completed
+    customer.subscription.created
+    customer.subscription.updated
+    customer.subscription.deleted
+    invoice.paid
+    invoice.payment_failed
+    payment_intent.succeeded
+    payment_intent.payment_failed
+  ].freeze
+
+  def perform(event_id)
+    event = Event.find_by(external_id: event_id)
+
+    return unless event.pending? && ALLOWED_EVENTS.include?(event.name)
+
+    case event.name
+    when "customer.subscription.created"
+      ProcessCustomerSubscriptionCreatedJob.perform_later(event.external_id)
+    when "customer.subscription.deleted"
+      ProcessCustomerSubscriptionDeletedJob.perform_later(event.external_id)
+    when "customer.subscription.updated"
+      # TODO: Sync subscription changes
+      # ProcessCustomerSubscriptionUpdatedJob.perform_later(event.external_id)
+    when "invoice.paid"
+      ProcessInvoicePaidJob.perform_later(event.external_id)
+    when "invoice.payment_failed"
+      # TODO: Mark subscription as past_due
+      # ProcessInvoicePaymentFailedJob.perform_later(event.external_id)
+    when "payment_intent.succeeded"
+      # TODO: Handle successful one-time payment
+      # ProcessPaymentIntentSucceededJob.perform_later(event.external_id)
+    when "payment_intent.payment_failed"
+      # TODO: Handle failed one-time payment
+      # ProcessPaymentIntentFailedJob.perform_later(event.external_id)
+    else
+      Rails.logger.warn "⚠️ No job assigned for event: #{event.name}"
+    end
+  end
+end

--- a/app/jobs/process_customer_subscription_created_job.rb
+++ b/app/jobs/process_customer_subscription_created_job.rb
@@ -1,0 +1,65 @@
+require "stripe"
+
+class ProcessCustomerSubscriptionCreatedJob < ApplicationJob
+  class MissingStripeCustomerError < StandardError; end
+
+  queue_as :default
+
+  def perform(event_id)
+    event = Event.find_by(
+      external_id: event_id,
+      name: "customer.subscription.created"
+    )
+
+    return unless event.pending?
+
+    event.processing!
+
+    begin
+      customer = find_or_create_customer!(event)
+      create_subscription!(event, customer)
+      event.finished!
+      Rails.logger.info "✅ Successfully processed event (event_id: #{event_id})"
+    rescue MissingStripeCustomerError => e
+      event.failed!
+      Rails.logger.error "⚠️ Aborting event (event_id: #{event_id}) - Missing Stripe Customer ID: #{e.message}"
+      # TODO: Notify the team about the missing Stripe Customer ID.
+    rescue => e
+      Rails.logger.error "❌ Failed to process event (event_id: #{event_id}): #{e.message}"
+      event.pending!
+    end
+  end
+
+  private
+
+  def find_or_create_customer!(event)
+    external_id = event.payload.dig("data", "object", "customer")
+
+    raise MissingStripeCustomerError, "Missing Stripe Customer ID !!!" if external_id.blank?
+
+    customer = Customer.find_by(external_id: external_id)
+
+    return customer if customer.present?
+
+    stripe_customer = Stripe::Customer.retrieve(external_id)
+
+    customer = Customer.create!(
+      external_id: external_id,
+      email: stripe_customer.email,
+      name: stripe_customer.name
+    )
+
+    customer
+  end
+
+  def create_subscription!(event, customer)
+    subscription_data = event.payload.dig("data", "object")
+    external_id = subscription_data["id"]
+
+    # TODO: Consider fetching the latest subscription details from Stripe before creating/updating locally.
+
+    customer.subscriptions.find_or_create_by!(external_id:) do |subscription|
+      subscription.status = Subscription::UNPAID
+    end
+  end
+end

--- a/app/jobs/process_customer_subscription_deleted_job.rb
+++ b/app/jobs/process_customer_subscription_deleted_job.rb
@@ -1,0 +1,51 @@
+class ProcessCustomerSubscriptionDeletedJob < ApplicationJob
+  queue_as :default
+
+  def perform(event_id)
+    event = Event.find_by(external_id: event_id, name: "customer.subscription.deleted")
+
+    return unless event&.pending?
+
+    event.processing!
+
+    begin
+      subscription = find_subscription_or_retry(event)
+      return if subscription.nil?
+      subscription.canceled!
+      event.finished!
+    rescue => e
+      Rails.logger.error "❌ Failed to process event (event_id: #{event_id}): #{e.message}"
+      event.pending!
+    end
+  end
+
+  private
+
+  def find_subscription_or_retry(event)
+    external_id = event.payload.dig("data", "object", "id")
+
+    unless external_id
+      Rails.logger.warn "⚠️ No subscription ID in customer.subscription.deleted event (event_id: #{event.external_id}). Retrying later."
+      return retry!(event)
+    end
+
+    subscription = Subscription.find_by(external_id:)
+
+    unless subscription
+      Rails.logger.warn "⚠️ Subscription not found (external_id: #{external_id}). Retrying later."
+      return retry!(event)
+    end
+
+    unless subscription.active?
+      Rails.logger.warn "⚠️ Subscription not paid (external_id: #{external_id}). Cannot cancel yet. Retrying later."
+      return retry!(event)
+    end
+
+    subscription
+  end
+
+  def retry!(event)
+    event.pending!
+    nil
+  end
+end

--- a/app/jobs/process_invoice_paid_job.rb
+++ b/app/jobs/process_invoice_paid_job.rb
@@ -1,0 +1,48 @@
+class ProcessInvoicePaidJob < ApplicationJob
+  queue_as :default
+
+  def perform(event_id)
+    event =  Event.find_by(external_id: event_id, name: "invoice.paid")
+
+    return unless event.pending?
+
+    event.processing!
+
+    begin
+      # TODO: Currently, we only process subscription payments.
+      # In the future, we should generalize this to handle other invoice-based payments (e.g., one-time purchases).
+      subscription = find_subscription_or_retry(event)
+      return if subscription.nil? # Exit early if we need to retry
+
+      subscription.active!
+      event.finished!
+    rescue => e
+      Rails.logger.error "❌ Failed to process event (event_id: #{event_id}): #{e.message}"
+      event.pending!
+    end
+  end
+
+  private
+
+  def find_subscription_or_retry(event)
+    external_id = event.payload.dig("data", "object", "subscription")
+
+    unless external_id
+      # TODO: invoice.paid` can apply to various payments, not just subscriptions.
+      # Currently, we retry the event, but we may need a more specific handling strategy.
+      Rails.logger.warn "⚠️ No subscription ID in invoice.paid payload (event_id: #{event.external_id}). Skipping."
+      event.pending!
+      return nil
+    end
+
+    subscription = Subscription.find_by(external_id:)
+
+    unless subscription
+      Rails.logger.warn "⚠️ Subscription not found (external_id: #{external_id}). Retrying later..."
+      event.pending!
+      return nil
+    end
+
+    subscription
+  end
+end

--- a/app/models/stripe_event.rb
+++ b/app/models/stripe_event.rb
@@ -1,12 +1,2 @@
 class StripeEvent < Event
-  ALLOWED_EVENTS = %w[
-    checkout.session.completed
-    customer.subscription.created
-    customer.subscription.updated
-    customer.subscription.deleted
-    invoice.paid
-    invoice.payment_failed
-    payment_intent.succeeded
-    payment_intent.payment_failed
-  ].freeze
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,16 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  namespace :webhooks do
+    resource :stripe, only: :create, controller: "stripe"
+  end
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  resources :subscriptions, only: %i[index]
+
+  # Default dev:secret.
+  # Run `rails credentials:edit` to set basic authentication credentials.
+  # More info: https://github.com/rails/mission_control-jobs#authentication
+  mount MissionControl::Jobs::Engine, at: "/jobs"
+
+
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  root to: "subscriptions#index"
 end

--- a/spec/jobs/event_processor_job_spec.rb
+++ b/spec/jobs/event_processor_job_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe EventProcessorJob, type: :job do
+  subject(:process_event) { described_class.perform_now(event.external_id) }
+
+  describe '#perform' do
+    context 'when the event is customer.subscription.created' do
+      let(:event) { create(:event, :subscription_created) }
+
+      it 'enqueues ProcessCustomerSubscriptionCreatedJob with the correct external_id' do
+        expect(ProcessCustomerSubscriptionCreatedJob).to receive(:perform_later).with(event.external_id)
+        process_event
+      end
+    end
+
+    context 'when the event is invoice.paid' do
+      let(:event) { create(:event, :invoice_paid) }
+
+      it 'enqueues ProcessInvoicePaidJob with the correct external_id' do
+        expect(ProcessInvoicePaidJob).to receive(:perform_later).with(event.external_id)
+        process_event
+      end
+    end
+
+    context 'when the event is customer.subscription.deleted' do
+      let(:event) { create(:event, :subscription_deleted) }
+
+      it 'enqueues ProcessCustomerSubscriptionDeletedJob with the correct external_id' do
+        expect(ProcessCustomerSubscriptionDeletedJob).to receive(:perform_later).with(event.external_id)
+        process_event
+      end
+    end
+  end
+end

--- a/spec/jobs/process_customer_subscription_created_job_spec.rb
+++ b/spec/jobs/process_customer_subscription_created_job_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe ProcessCustomerSubscriptionCreatedJob, type: :job do
+  subject(:process_subscription_created) { described_class.perform_now(event.external_id) }
+
+  let(:customer_external_id) { "cus_#{SecureRandom.hex(8)}" }
+  let(:subscription_external_id) { "sub_#{SecureRandom.hex(8)}" }
+  let(:stripe_customer_mock) { OpenStruct.new(id: customer_external_id, email: "test@example.com", name: "John Doe") }
+
+  before do
+    allow(Stripe::Customer).to receive(:retrieve).with(customer_external_id).and_return(stripe_customer_mock)
+  end
+
+  describe '#perform' do
+    context 'when the event has a valid customer' do
+      let(:event) { create(:event, :subscription_created, payload: { 'data' => { 'object' => { 'customer' => customer_external_id, 'id' => subscription_external_id } } }) }
+
+      it 'creates a customer and subscription' do
+        expect { process_subscription_created }
+          .to change(Customer, :count).by(1)
+          .and change(Subscription, :count).by(1)
+      end
+    end
+
+    context 'when the customer ID is missing' do
+      let(:event) { create(:event, :subscription_created, payload: { 'data' => { 'object' => {} } }) }
+
+      it 'logs an error and marks the event as failed' do
+        expect(Rails.logger).to receive(:error).with(/Missing Stripe Customer ID/)
+        process_subscription_created
+        expect(event.reload.status).to eq('failed')
+      end
+    end
+  end
+end

--- a/spec/jobs/process_customer_subscription_deleted_job_spec.rb
+++ b/spec/jobs/process_customer_subscription_deleted_job_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ProcessCustomerSubscriptionDeletedJob, type: :job do
+  subject(:process_subscription_deleted) { described_class.perform_now(event.external_id) }
+
+  describe '#perform' do
+    context 'when the subscription exists and is paid' do
+      let(:event) { create(:event, :subscription_deleted) }
+      let!(:subscription) { create(:subscription, external_id: event.payload.dig('data', 'object', 'id'), status: 'active') }
+
+      it 'marks the subscription as canceled' do
+        expect { process_subscription_deleted }
+          .to change { subscription.reload.status }
+          .from('active')
+          .to('canceled')
+      end
+    end
+
+    context 'when the subscription does not exist' do
+      let(:event) { create(:event, :subscription_deleted) }
+
+      it 'logs a warning and leaves the event pending' do
+        expect(Rails.logger).to receive(:warn).with(/Subscription not found/)
+        process_subscription_deleted
+        expect(event.reload.status).to eq('pending')
+      end
+    end
+
+    context 'when the subscription is not paid' do
+      let(:event) { create(:event, :subscription_deleted) }
+      let!(:subscription) { create(:subscription, external_id: event.payload.dig('data', 'object', 'id'), status: 'unpaid') }
+
+      it 'logs a warning and leaves the event pending' do
+        expect(Rails.logger).to receive(:warn).with(/Subscription not paid/)
+        process_subscription_deleted
+        expect(event.reload.status).to eq('pending')
+      end
+    end
+  end
+end

--- a/spec/jobs/process_invoice_paid_job_spec.rb
+++ b/spec/jobs/process_invoice_paid_job_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe ProcessInvoicePaidJob, type: :job do
+  subject(:process_invoice_paid) { described_class.perform_now(event.external_id) }
+
+  describe '#perform' do
+    context 'when the invoice is associated with a subscription' do
+      let(:event) { create(:event, :invoice_paid) }
+      let!(:subscription) { create(:subscription, external_id: event.payload.dig('data', 'object', 'subscription'), status: 'unpaid') }
+
+      it 'marks the subscription as active' do
+        expect { process_invoice_paid }
+          .to change { subscription.reload.status }
+          .from('unpaid')
+          .to('active')
+      end
+    end
+
+    context 'when the invoice does not have a subscription ID' do
+      let(:event) { create(:event, :invoice_paid, payload: { 'data' => { 'object' => {} } }) }
+
+      it 'logs a warning and does not process the event' do
+        expect(Rails.logger).to receive(:warn).with(/No subscription ID in invoice.paid payload/)
+        expect { process_invoice_paid }.not_to change(Subscription, :count)
+      end
+    end
+
+    context 'when the subscription does not exist' do
+      let(:event) { create(:event, :invoice_paid) }
+
+      it 'logs a warning and leaves the event pending' do
+        expect(Rails.logger).to receive(:warn).with(/Subscription not found/)
+        process_invoice_paid
+        expect(event.reload.status).to eq('pending')
+      end
+    end
+  end
+end

--- a/spec/requests/webhooks/stripe_controller_spec.rb
+++ b/spec/requests/webhooks/stripe_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe Webhooks::StripeController, type: :request do
+  subject(:send_webhook) { post webhooks_stripe_path, params: event_payload.to_json, headers: headers }
+
+  let(:event_id) { "evt_#{SecureRandom.hex(8)}" }
+  let(:event_type) { "customer.subscription.created" }
+  let(:stripe_event_mock) { OpenStruct.new(id: event_id, type: event_type, to_h: event_payload) }
+
+  let(:event_payload) do
+    {
+      "id" => event_id,
+      "type" => event_type,
+      "data" => { "object" => { "id" => "sub_123", "customer" => "cus_123" } }
+    }
+  end
+
+  let(:headers) do
+    {
+      "CONTENT_TYPE" => "application/json",
+      "HTTP_STRIPE_SIGNATURE" => "valid_signature"
+    }
+  end
+
+  before do
+    allow(Stripe::Webhook).to receive(:construct_event).and_return(stripe_event_mock)
+    allow(EventProcessorJob).to receive(:perform_later)
+  end
+
+  describe "POST /webhooks/stripe" do
+    context "when the signature is valid" do
+      it "creates an event and enqueues the job" do
+        expect { send_webhook }.to change(Event, :count).by(1)
+        expect(response).to have_http_status(:ok)
+        expect(EventProcessorJob).to have_received(:perform_later).with(event_id)
+      end
+    end
+
+    context "when the signature is invalid" do
+      before do
+        allow(Stripe::Webhook).to receive(:construct_event).and_raise(Stripe::SignatureVerificationError.new("Invalid signature", "sig_header"))
+      end
+
+      it "returns 400 Bad Request and does not create an event" do
+        expect { send_webhook }.not_to change(Event, :count)
+        expect(response).to have_http_status(:bad_request)
+        expect(response.body).to include("Invalid signature")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the Webhooks::StripeController to receive Stripe webhook events and process them asynchronously using background jobs.

- The controller verifies webhook signatures and stores incoming events in the database
- Events are assigned an initial "pending" status and checked for duplicates before processing
- EventProcessorJob routes events to specialized jobs based on event type

Implemented background jobs:

- ProcessCustomerSubscriptionCreatedJob to handle new subscriptions
- ProcessCustomerSubscriptionDeletedJob to cancel paid subscriptions
- ProcessInvoicePaidJob to mark subscriptions as paid